### PR TITLE
Included name for  'back_led' in YAML configuration

### DIFF
--- a/devices/ESP32-2432S028R.yaml
+++ b/devices/ESP32-2432S028R.yaml
@@ -44,6 +44,7 @@ light:
     name: Display Backlight
     restore_mode: ALWAYS_ON
   - id: led
+    name: back_led
     platform: rgb
     red: output_red
     green: output_green


### PR DESCRIPTION
Without the name the back_led entity does not appear in Homeassistant